### PR TITLE
Fix git up-to-date error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -618,8 +618,7 @@ func migrateProject(ctx context.Context, proj []string) error {
 		Force:      true,
 		//Prune:      true, // causes error, attempts to delete main branch
 	}); err != nil {
-		upToDateError := errors.New("already up-to-date")
-		if errors.As(err, &upToDateError) {
+		if errors.Is(err, git.NoErrAlreadyUpToDate) {
 			logger.Debug("repository already up-to-date on GitHub", "name", gitlabPath[1], "group", gitlabPath[0], "url", githubUrl)
 		} else {
 			return fmt.Errorf("pushing to github repo: %v", err)
@@ -851,8 +850,7 @@ func migratePullRequests(ctx context.Context, githubPath, gitlabPath []string, p
 					},
 					Force: true,
 				}); err != nil {
-					upToDateError := errors.New("already up-to-date")
-					if errors.As(err, &upToDateError) {
+					if errors.Is(err, git.NoErrAlreadyUpToDate) {
 						logger.Trace("branch already exists and is up-to-date on GitHub", "owner", githubPath[0], "repo", githubPath[1], "source_branch", mergeRequest.SourceBranch, "target_branch", mergeRequest.TargetBranch)
 					} else {
 						sendErr(fmt.Errorf("pushing temporary branches to github: %v", err))
@@ -1021,8 +1019,7 @@ func migratePullRequests(ctx context.Context, githubPath, gitlabPath []string, p
 				},
 				Force: true,
 			}); err != nil {
-				upToDateError := errors.New("already up-to-date")
-				if errors.As(err, &upToDateError) {
+				if errors.Is(err, git.NoErrAlreadyUpToDate) {
 					logger.Trace("branches already deleted on GitHub", "owner", githubPath[0], "repo", githubPath[1], "pr_number", pullRequest.GetNumber(), "source_branch", mergeRequest.SourceBranch, "target_branch", mergeRequest.TargetBranch)
 				} else {
 					sendErr(fmt.Errorf("pushing branch deletions to github: %v", err))


### PR DESCRIPTION
This PR updates the error handling logic for git push operations to correctly detect when a repository or branch is already up-to-date. Previously, the code used `errors.As` with a newly created error instance, which is not the optimal way to check for errors in Go.

### Details

- Replaces all instances of:
  ```go
  upToDateError := errors.New("already up-to-date")
  if errors.As(err, &upToDateError) { ... }
  ```
  with the idiomatic:
  ```go
  if errors.Is(err, git.NoErrAlreadyUpToDate) { ... }
  ```
- This ensures that the code properly recognizes the `already up-to-date` condition as returned by the `go-git` library, improving reliability and correctness.

### Why

- `errors.Is` is the recommended way to check for sentinel errors in Go.
- The previous approach would never match the actual error returned by the library, potentially causing unnecessary error handling or log noise.

No functional changes to migration logic; this is a correctness and maintainability improvement.

---

** Any feedback is more than welcome! **