### PR TITLE
Support max merge requests age

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Written in Go, this is a cross-platform CLI utility that accepts the following r
         continue migrating until canceled
   -max-concurrency int
         how many projects to migrate in parallel (default 4)
+  -merge-requests-max-age string
+        optional maximum age in days of merge requests to migrate
   -migrate-pull-requests
         whether pull requests should be migrated
   -projects-csv string
@@ -59,6 +61,8 @@ Written in Go, this is a cross-platform CLI utility that accepts the following r
         report on primitives to be migrated instead of beginning migration
   -skip-invalid-merge-requests
         when true, will log and skip invalid merge requests instead of raising an error
+  -version
+        output version information
 ```
 
 ## Authentication
@@ -97,6 +101,8 @@ As a bonus, if your GitLab users add the URL to their GitHub profile in the `Web
 This tool also migrates merged/closed merge requests from your GitLab projects. It does this by reconstructing temporary branches in each repo, pushing them to GitHub, creating then closing the pull request, and lastly deleting the temporary branches. Once the tool has completed, you should not have any of these temporary branches in your repo - although GitHub will not garbage collect them immediately such that you can click the `Restore branch` button in any of these PRs.
 
 If you have a large number of merge requests, or projects with a long history spanning many GitLab upgrades, you may wish to specify the `-skip-invalid-merge-requests` argument. This will cause the tool to emit INFO messages for merge requests that it considers invalid, such as those that are still marked as Open but have no source/head branch, or where there is no diff for a closed merge request. Without this option, an error will be logged instead.
+
+Similarly, you can specify a maximum age for merge requests to migrate with the `-merge-requests-max-age` argument, which is useful for 'topping off' projects that are already migrated.
 
 _Example migrated pull request (open)_
 

--- a/main.go
+++ b/main.go
@@ -86,18 +86,6 @@ func main() {
 
 	cache = newObjectCache()
 
-	githubToken = os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		logger.Error("missing environment variable", "name", "GITHUB_TOKEN")
-		os.Exit(1)
-	}
-
-	gitlabToken = os.Getenv("GITLAB_TOKEN")
-	if gitlabToken == "" {
-		logger.Error("missing environment variable", "name", "GITLAB_TOKEN")
-		os.Exit(1)
-	}
-
 	var showVersion bool
 	fmt.Printf(fmt.Sprintf("gitlab-migrator %s\n", version))
 
@@ -124,6 +112,18 @@ func main() {
 
 	if showVersion {
 		return
+	}
+
+	githubToken = os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		logger.Error("missing environment variable", "name", "GITHUB_TOKEN")
+		os.Exit(1)
+	}
+
+	gitlabToken = os.Getenv("GITLAB_TOKEN")
+	if gitlabToken == "" {
+		logger.Error("missing environment variable", "name", "GITLAB_TOKEN")
+		os.Exit(1)
 	}
 
 	if githubUser == "" {

--- a/project.go
+++ b/project.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
@@ -240,6 +241,10 @@ func (p *project) migrateMergeRequests(ctx context.Context) {
 	opts := &gitlab.ListProjectMergeRequestsOptions{
 		OrderBy: pointer("created_at"),
 		Sort:    pointer("asc"),
+	}
+
+	if mergeRequestsAge > 0 {
+		opts.CreatedAfter = pointer(time.Now().AddDate(0, 0, -mergeRequestsAge))
 	}
 
 	logger.Debug("retrieving GitLab merge requests", "name", p.gitlabPath[1], "group", p.gitlabPath[0], "project_id", p.project.ID)


### PR DESCRIPTION
Add the `-merge-requests-max-age` argument, for 'topping off' projects that are already migrated without iterating through the entire merge request history.