### PR TITLE
Fix -skip-invalid-merge-requests flag to handle missing commits

### DIFF
--- a/project.go
+++ b/project.go
@@ -428,7 +428,11 @@ func (p *project) migrateMergeRequest(ctx context.Context, mergeRequest *gitlab.
 		logger.Trace("inspecting start commit", "name", p.gitlabPath[1], "group", p.gitlabPath[0], "project_id", p.project.ID, "merge_request_id", mergeRequest.IID, "sha", mergeRequestCommits[0].ShortID)
 		startCommit, err := object.GetCommit(p.repo.Storer, plumbing.NewHash(mergeRequestCommits[0].ID))
 		if err != nil {
-			return false, fmt.Errorf("loading start commit: %v", err)
+			if skipInvalidMergeRequests {
+				logger.Info("skipping invalid merge request as start commit does not exist", "name", p.gitlabPath[1], "group", p.gitlabPath[0], "project_id", p.project.ID, "merge_request_id", mergeRequest.IID, "missing_commit", mergeRequestCommits[0].ShortID, "error", err)
+				return false, nil
+			}
+			return false, fmt.Errorf("loading start commit %s: %v", mergeRequestCommits[0].ShortID, err)
 		}
 
 		if startCommit.NumParents() == 0 {
@@ -470,6 +474,16 @@ func (p *project) migrateMergeRequest(ctx context.Context, mergeRequest *gitlab.
 
 		endHash := plumbing.NewHash(mergeRequestCommits[len(mergeRequestCommits)-1].ID)
 		logger.Trace("creating source branch for merged/closed merge request", "name", p.gitlabPath[1], "group", p.gitlabPath[0], "project_id", p.project.ID, "merge_request_id", mergeRequest.IID, "branch", mergeRequest.SourceBranch, "sha", endHash)
+
+		// Validate that the end commit exists before attempting checkout
+		if _, err = object.GetCommit(p.repo.Storer, endHash); err != nil {
+			if skipInvalidMergeRequests {
+				logger.Info("skipping invalid merge request as end commit does not exist", "name", p.gitlabPath[1], "group", p.gitlabPath[0], "project_id", p.project.ID, "merge_request_id", mergeRequest.IID, "missing_commit", mergeRequestCommits[len(mergeRequestCommits)-1].ShortID, "error", err)
+				return false, nil
+			}
+			return false, fmt.Errorf("loading end commit %s: %v", mergeRequestCommits[len(mergeRequestCommits)-1].ShortID, err)
+		}
+
 		if err = worktree.Checkout(&git.CheckoutOptions{
 			Create: true,
 			Force:  true,


### PR DESCRIPTION
The flag previously only handled the case where a start commit had no parents (orphaned commits), but did not handle cases where commits referenced in merge request metadata no longer exist in the repository (typically due to force-pushes after the merge request was closed).

Changes:
- Add skip-logic for missing start commits (project.go:436-443) When a start commit cannot be loaded from the repository, check the skipInvalidMergeRequests flag and log as INFO instead of ERROR

- Add validation and skip-logic for missing end commits (project.go:486-492) Validate that the end commit exists before attempting to checkout the temporary source branch. Apply same skip-logic as start commits.

- Improve error messages to include the commit hash for better debugging

This ensures that when -skip-invalid-merge-requests is specified, ALL merge requests with missing commits are gracefully skipped with INFO logging instead of failing with ERROR, resulting in a clean exit code.

Fixes issue where migrations would report errors even with the skip flag enabled, when merge requests referenced commits that were removed from Git history via force-push operations.